### PR TITLE
Fixing the issue with Accessory.staticSelect

### DIFF
--- a/lib/Accessory/index.js
+++ b/lib/Accessory/index.js
@@ -46,10 +46,14 @@ class Accessory {
     actionId,
     placeholder = "Pick an option",
   }) {
+    let initialOptionClone;
     const optionsClone = options.map((o) => ({
       text: { type: 'plain_text', text: o.text },
       value: o.value
     }));
+    if(initialOption){
+      initialOptionClone = optionsClone.find((o) => o.value === initialOption);
+    }
     const element = {
       accessory: {
         type: "static_select",
@@ -64,8 +68,8 @@ class Accessory {
     if (actionId) {
       element.accessory.action_id = actionId;
     }
-    if (initialOption) {
-      element.accessory.initial_option = optionsClone.find((o) => o.value === initialOption);
+    if (initialOptionClone) {
+      element.accessory.initial_option = initialOptionClone
     }
     return element;
   }

--- a/lib/Accessory/index.js
+++ b/lib/Accessory/index.js
@@ -46,13 +46,14 @@ class Accessory {
     actionId,
     placeholder = "Pick an option",
   }) {
+    const optionsClone = options.map((o) => ({
+      text: { type: 'plain_text', text: o.text },
+      value: o.value
+    }));
     const element = {
       accessory: {
         type: "static_select",
-        options: options.map((o) => ({
-          text: { type: "plain_text", text: o.text },
-          value: o.value,
-        })),
+        options: optionsClone,
         placeholder: {
           type: "plain_text",
           text: placeholder,
@@ -64,7 +65,7 @@ class Accessory {
       element.accessory.action_id = actionId;
     }
     if (initialOption) {
-      element.accessory.initial_option = initialOption;
+      element.accessory.initial_option = optionsClone.find((o) => o.value === initialOption);
     }
     return element;
   }


### PR DESCRIPTION
- The PR fixes the issue with `Accessory.staticSelect`

- When passing the `initialOption`, we assign it directly to `initial_option`
- In many of our views, we pass the `value` directly to `initialOption`  whereas the expected format is
```
{ text: { text, type: 'plain_text' }, value }
```
- Hence we should
   1. Either add logic to select `initialOption` from the list of passed `options` inside block-kit-builder
   2. Or we pass the `initialOption` in the expected format.

The former sounds like an easy change to incorporate and apply plus would make it consistent hence applying that.