### PR TITLE
Fixes initial_option in checkbox

### DIFF
--- a/lib/Input/index.js
+++ b/lib/Input/index.js
@@ -311,14 +311,6 @@ class Input {
     optional,
     asInput = true,
   }) {
-    const initOpts = initialOptions
-      ? options
-          .filter((o) => initialOptions.includes(o.value))
-          .map((o) => ({
-            text: { type: "mrkdwn", text: o.text },
-            value: o.value,
-          }))
-      : undefined;
     const _options = options.map((o) => {
       const obj = { text: { type: "mrkdwn", text: o.text }, value: o.value };
       if (o.description) {
@@ -326,6 +318,10 @@ class Input {
       }
       return obj;
     });
+    const initOpts = initialOptions
+      ? _options
+        .filter((o) => initialOptions.includes(o.value))
+      : undefined;
     const element = {
       type: "checkboxes",
       options: _options,


### PR DESCRIPTION
### Context
- For `initial_options` to work we need provide an exact same object as initial options from `options`.
- [Link to doc](https://api.slack.com/reference/block-kit/block-elements#:~:text=initial_options,checkbox%20group%20initially%20loads.)

### Issue
- With current implementation we doing a `map` over the object found from `options`. This is not required.
```js
const initOpts = initialOptions
      ? options
          .filter((o) => initialOptions.includes(o.value))
          .map((o) => ({
            text: { type: "mrkdwn", text: o.text },
            value: o.value,
          }))
      : undefined;
```
- We can make this work by adding conditional check if `description` exists then add to `initial_option`. 
- Better approach is to fetch `initial_options` after we have computed `_options`.