### PR TITLE
Url support added in overflow accessory

### DIFF
--- a/lib/Accessory/index.js
+++ b/lib/Accessory/index.js
@@ -76,7 +76,7 @@ class Accessory {
 
   /**
    * Overflow accessory
-   * @param {Array<{text:String, value:String}>} options list of items to show in the overflow menu
+   * @param {Array<{text:String, value:String, url:String}>} options list of items to show in the overflow menu
    * @param {String} [actionId] optional action id
    * @param {Object} [dialog] optional confirm object
    * @param {String} dialog.title title of the confirm dialog
@@ -92,6 +92,7 @@ class Accessory {
         options: options.map((o) => ({
           text: { type: "plain_text", text: o.text },
           value: o.value,
+          ...(o.url && { url: o.url })
         })),
       },
     };


### PR DESCRIPTION
If url exists in the options data, then it would be added in the overflow!

Test: Added http://www.google.com in the overflow option of pulse
https://www.loom.com/share/8bb4a630d3e34d39b4d5c8b6f711b8cb